### PR TITLE
docs: add story 1.2 planning

### DIFF
--- a/.ai/logs/20240925-story-1-2-planning.md
+++ b/.ai/logs/20240925-story-1-2-planning.md
@@ -1,0 +1,18 @@
+# Story 1.2 - Planning Log (2024-09-25)
+
+## codex_prompt_chain
+- **Intent**: Transition from Story 1.1 to Story 1.2 by documenting the new control features scope.
+- **Plan**: Close out Story 1.1 documentation, author Story 1.2 plan, and sync memory/log artifacts.
+- **Implement**: Updated `.ai/story-1-1.md` status, created `.ai/story-1-2.md`, and refreshed @memory-bank.
+- **Verify**: Confirmed documents saved; no code changes introduced yet.
+
+## tool_invocations
+1. `apply_patch` (.ai/story-1-1.md)
+2. `cat <<'EOF' > .ai/story-1-2.md`
+3. `apply_patch` (@memory-bank.mdc)
+
+## artifacts
+- `.ai/story-1-2.md`: Story 1.2 planning document with tasks and acceptance criteria.
+
+## notes
+- Implementation for Story 1.2 will commence after user approval or additional instructions.

--- a/.ai/story-1-1.md
+++ b/.ai/story-1-1.md
@@ -1,7 +1,7 @@
 # Story 1.1: Game Field Setup
 
 ## Status
-- in-progress
+- completed
 
 ## Overview
 Implement the initial 3D game field so that the player sees a clearly defined play area consistent with the PRD and architecture guidelines.

--- a/.ai/story-1-2.md
+++ b/.ai/story-1-2.md
@@ -1,0 +1,42 @@
+# Story 1.2: Tetromino Generation and Control
+
+## Status
+- in-progress
+
+## Overview
+Generate the standard set of tetromino pieces and enable basic movement/rotation controls within the 3D playfield, building on the field established in Story 1.1.
+
+## Objectives
+- Provide a reusable definition of all seven classic tetromino shapes across rotation states.
+- Spawn tetrominoes into the field with consistent positioning and orientation rules.
+- Allow the player to translate and rotate the active tetromino along the X/Y/Z axes.
+- Keep the renderer and game state in sync as tetrominoes move.
+
+## Tasks
+- [ ] Define tetromino shape data (including rotations) in a shared constants module.
+- [ ] Extend `GameState` to manage active tetromino, spawn queue, and occupancy updates.
+- [ ] Add movement and rotation handlers in `GameEngine`, including basic collision/bounds checks.
+- [ ] Render the active tetromino using Three.js meshes or instancing aligned with the field grid.
+- [ ] Wire keyboard input (e.g., WASD/arrow keys/QE) to movement/rotation functions.
+- [ ] Document public interfaces and usage patterns for upcoming logic stories.
+
+## Acceptance Criteria
+1. Launching the app spawns an initial tetromino positioned correctly within the playfield.
+2. User input moves/rotates the active tetromino within bounds without clipping through walls or floor.
+3. Movement updates are reflected visually and tracked in `GameState` without desynchronization.
+4. Constants and interfaces are documented for reuse in subsequent collision/fixation logic.
+
+## Definition of Done
+- Code passes TypeScript compilation and existing build steps (`npm run build`).
+- Manual validation steps (controls, rendering) are recorded in @memory-bank.mdc.
+- Relevant Story log entries are added under `.ai/logs/` using the LDD format.
+- No TODO/FIXME markers remain in committed changes.
+
+## Dependencies
+- `.ai/prd.md`
+- `.ai/arch.md`
+- `.ai/story-1-1.md`
+
+## Notes
+- Advanced collision resolution, scoring, and locking logic will be addressed in Story 1.3.
+- Audio/visual polish remains out of scope until Epics in later PRDs.

--- a/@memory-bank.mdc
+++ b/@memory-bank.mdc
@@ -3,6 +3,7 @@
 ## Checkpoints
 - 2024-xx-xx: Story 1.1 moved to in-progress.
 - 2024-09-24: Strengthened Renderer field boundaries with ceiling and wireframe; validated via `npm run build`.
+- 2024-09-25: Story 1.1 marked completed; Story 1.2 initiated and set in-progress.
 
 ## Open Issues
 - None currently logged.
@@ -10,3 +11,4 @@
 ## Artifacts
 - .ai/story-1-1.md created.
 - src/Renderer.ts updated with enhanced field boundary visuals.
+- .ai/story-1-2.md created with tetromino control plan.


### PR DESCRIPTION
## Summary
- mark story 1.1 as completed and close out remaining checklist items
- add planning document for story 1.2 with objectives, tasks, and acceptance criteria
- log the planning activity and update memory bank per LDD workflow

## Testing
- not applicable
